### PR TITLE
Sync to v1.0.2 — Windows Debug UTF-8 fix, simplified docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,58 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+---
+name: Bug report
+about: Report a problem with Remove Samples for NZBGet
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+### Pre-flight
+- [ ] I updated Remove Samples via NZBGet **Extension Manager** and retested.
+- [ ] I read the README and Troubleshooting notes.
+
+### Environment
+- **Platform:** Docker (Linux) | Unraid | Linux | Windows | macOS
+- **NZBGet version:** v23.x
+- **Remove Samples version:** 1.0.x
+- **Python version:** (if known)
+
+### Extensions order (from _Settings → Categories_)
+1) Completion
+2) PasswordDetector
+3) FakeDetector
+4) ExtendedUnpacker
+5) Remove Samples
+6) Clean
+
+### Remove Samples settings
+- Remove Directories: Yes/No
+- Remove Files: Yes/No
+- Video threshold (MB): 150 (default)
+- Audio threshold (MB): 2 (default)
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Example filenames/sizes
+- `movie.sample.mkv` (90 MB)
+- `movie.mkv` (1.4 GB)
+
+### Expected
+<!-- What you expected to happen -->
+
+### Actual
+<!-- What actually happened -->
+
+### Debug log (short snippet)
+> Turn **Debug = Yes** temporarily, reproduce once, paste key lines. Redact personal paths.

--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.8'
     

--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -30,7 +30,7 @@ jobs:
       run: prospector --zero-exit main.py
     
     - name: Upload Prospector report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: prospector-report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     

--- a/README.md
+++ b/README.md
@@ -1,256 +1,71 @@
-# RemoveSamples - NZBGet Extension
-
-[![Tests](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/tests.yml/badge.svg)](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/tests.yml)
-[![Prospector](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/prospector.yml/badge.svg)](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/prospector.yml)
-[![Manifest Check](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/manifest.yml/badge.svg)](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/actions/workflows/manifest.yml)
-
-**Modern NZBGet extension** for intelligent sample file detection and removal. Automatically cleans sample files and directories before Sonarr/Radarr/Lidarr/Prowlarr processing.
-
-> 🔄 **Replaces the legacy DeleteSamples.py script** with modern extension format and advanced detection algorithms.
-
-## 🚀 Quick Start
-
-**📖 [Complete Documentation](../../wiki/Home)** | **🚀 [Installation Guide](../../wiki/02_Installation_Guide)** | **⚙️ [Configuration Reference](../../wiki/03_Configuration_Reference)**
-
-## ✨ Key Features
-
-- 🎯 **Smart Detection**: Advanced pattern matching with word boundary detection
-- 📁 **Directory Cleanup**: Removes entire sample directories (`samples/`, `SAMPLE/`)
-- 🎬 **Video Support**: Configurable size thresholds for different quality levels
-- 🎵 **Audio Support**: Separate detection logic for audio samples
-- ⚙️ **Modern Interface**: GUI dropdown configuration (no file editing!)
-- 🐳 **Docker Ready**: Works with all popular NZBGet Docker containers
-- 🔧 **Flexible**: Independent control over file and directory removal
-- 🛡️ **Enterprise-Grade**: Automated security scanning and dependency monitoring
-
-## 🆚 Why Choose RemoveSamples?
-
-**vs DeleteSamples.py (Legacy Script)**
-
-| Feature | DeleteSamples.py | RemoveSamples |
-|---------|-----------------|---------------|
-| **Configuration** | ❌ Manual file editing | ✅ Modern dropdown interface |
-| **Directory Removal** | ❌ Files only | ✅ Files AND directories |
-| **Extension Format** | ❌ Legacy script | ✅ Modern NZBGet extension |
-| **Pattern Detection** | ❌ Basic substring | ✅ Advanced pattern matching |
-| **Audio Support** | ❌ Limited | ✅ Full configurable support |
-| **Maintenance** | ❌ Abandoned (6+ years) | ✅ Active development |
-
-**[See detailed comparison →](../../wiki/09_Comparison_DeleteSamples)**
-
-## 📦 Installation
-
-### Method 1: Extension Manager (Recommended)
-1. Open NZBGet web interface
-2. Go to **Settings** → **Extension Manager**
-3. Find "RemoveSamples" in the list
-4. Click **Install**
-
-### Method 2: Manual Installation
-```bash
-# Download and extract to NZBGet scripts directory
-mkdir -p /path/to/nzbget/scripts/RemoveSamples/
-# Copy main.py and manifest.json
-chmod 755 main.py && chmod 644 manifest.json
-```
-
-### Method 3: Docker/Unraid
-```bash
-# For Unraid NZBGet containers
-cd /mnt/user/appdata/nzbget/scripts/
-mkdir -p RemoveSamples
-# Download files and set permissions for nobody:users
-```
-
-**📖 [Detailed installation instructions for all platforms →](../../wiki/02_Installation_Guide)**
-
-## ⚙️ Configuration
-
-### Basic Settings (Dropdown Interface)
-```
-Remove Directories: Yes    # Delete sample directories
-Remove Files: Yes          # Delete sample files  
-Debug: No                  # Enable for troubleshooting
-```
-
-### Advanced Thresholds
-```
-Video Size Threshold: 150 MB    # 720p: 50MB, 1080p: 100MB, 4K: 300MB+
-Audio Size Threshold: 2 MB      # ~30 seconds of 320kbps MP3
-```
-
-### Recommended Settings by Use Case
-
-**Conservative (New Users)**
-```
-Video: 300 MB | Audio: 5 MB | Debug: Yes
-```
-
-**Balanced (Most Users)**
-```
-Video: 150 MB | Audio: 2 MB | Debug: No
-```
-
-**Aggressive (High Volume)**
-```
-Video: 50 MB | Audio: 1 MB | Debug: No
-```
-
-**📖 [Complete configuration guide →](../../wiki/03_Configuration_Reference)**
-
-## 🔄 Workflow Integration
-
-### Recommended Script Order
-```
-1. PasswordDetector (if used)
-2. FakeDetector (if used)
-3. RemoveSamples ← Place here
-4. Clean (if used)
-5. Other scripts
-```
+# Remove Samples • NZBGet Extension
 
-### Media Manager Integration
-- **Sonarr**: Cleaner TV episode imports, no sample episodes
-- **Radarr**: No trailer/sample files in movie folders  
-- **Lidarr**: No 30-second preview tracks in albums
-- **Prowlarr**: Consistent cleanup across all content types
+Removes “sample” files and sample folders **before** Sonarr/Radarr/Lidarr/Prowlarr process your downloads. Keeps your library clean with safe defaults.
 
-**📖 [Complete workflow integration guide →](../../wiki/05_Workflow_Integration)**
+## Install
 
-## 📊 Sample Detection Examples
+**NZBGet → Settings → Extension Manager**
 
-### ✅ Will Be Removed
-```
-Movie.Name.2023.sample.mkv      # Pattern + size match
-sample.mp4                      # Clear sample file
-preview_sample.avi              # Sample pattern
-samples/                        # Sample directory
-Small.video.under.150MB.mkv     # Size-based detection
-```
-
-### ❌ Will Be Preserved  
-```
-Movie.Name.2023.1080p.mkv       # Normal size, no pattern
-soundtrack.mp3                  # No sample pattern
-behind-the-scenes.mp4           # Above size threshold
-Movie.Title.SAMPLE.2023.mkv     # If "SAMPLE" in original title
-```
+1. Find **Remove Samples** in the list.
+2. Click the download/install icon.
+3. That’s it.
 
-## 🔍 Detection Logic
+## Configure
 
-### Pattern Matching
-- **Word boundary detection**: `\bsample\b` prevents false positives
-- **Multiple separators**: `.sample.`, `_sample.`, `-sample.`
-- **Directory patterns**: Comprehensive sample directory detection
+**NZBGet → Settings → Extension Manager → Remove Samples**
 
-### Size-Based Detection
-- **Separate thresholds** for video/audio files
-- **Configurable extensions** for each media type
-- **Smart combination** of pattern and size detection
-
-**📖 [Complete detection logic documentation →](../../wiki/06_Detection_Logic)**
-
-## 🐳 Docker & Container Support
-
-**Fully compatible with popular Docker containers:**
-- ✅ `linuxserver/nzbget` (Recommended)
-- ✅ `nzbget/nzbget` (Official)
-- ✅ Unraid Community Applications NZBGet
-- ✅ Custom Docker Compose setups
+* **Defaults** have been tested and should work for most users.
+* **Video size threshold:** **150 MB**
+* **Audio size threshold:** **2 MB**
+* **Remove Directories:** Yes
+* **Remove Files:** Yes
+* **Debug:** Leave **Off** under normal use. Turn **On only** during initial setup or when investigating an issue.
 
-**Container-specific installation guides available in documentation.**
+## Extensions order
 
-## 🚨 Troubleshooting
+**NZBGet → Settings → Categories → Category1.Extensions**
+Put **RemoveSamples** **after** unpacking and **before** any final cleanup or media managers.
 
-### Quick Diagnostics
-```bash
-# Enable debug mode
-Settings → Extension Manager → RemoveSamples → Debug: Yes
+**Example (working setup):**
 
-# Check logs
-Settings → Logging → Messages
+1. **Completion** – Verifies download completeness before processing
+2. **PasswordDetector** – Detects password-protected archives early
+3. **FakeDetector** – Flags fake/corrupted releases
+4. **ExtendedUnpacker** – Extracts nested zip/rar archives
+5. **RemoveSamples** – Removes sample files/folders **after unpack**
+6. **Clean** – Final tidy-up
 
-# Verify installation
-ls -la /path/to/scripts/RemoveSamples/
-# Should show: main.py (executable) and manifest.json
-```
+**Why order matters**
 
-### Common Issues
-- **Extension not appearing**: Check file permissions and restart NZBGet
-- **Files not removed**: Verify thresholds and enable debug mode
-- **Docker permissions**: Use container-appropriate user/group
+* Remove Samples runs **after unpack**, so it can see real files.
+* It runs **before Clean**, so samples are removed before final cleanup.
+* Upstream detection scripts run first to catch bad releases early.
 
-**📖 [Complete troubleshooting guide →](../../wiki/07_Troubleshooting_Guide)**
+## Quick test (optional)
 
-## 📞 Support & Documentation
+Turn **Debug = Yes**, process a test download, and review the log lines showing size checks and pattern matches.
+When you’re satisfied, set **Debug = No** for normal operation.
 
-- **📖 Complete Wiki**: [Comprehensive Documentation](../../wiki/01_Home)
-- **🐛 Bug Reports**: [GitHub Issues](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/issues)
-- **💬 Discussions**: [GitHub Discussions](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/discussions)
-- **🔒 Security Issues**: anunnaki.astronaut@machinamindmeld.com
-- **❓ FAQ**: [Frequently Asked Questions](../../wiki/08_FAQ)
+## Detection logic (short)
 
-## 🛡️ Security & Quality
+* **Word-boundary matching:** `\bsample\b` avoids false positives
+* **Separator-aware:** catches `.sample.`, `_sample_`, `-sample-`, etc.
+* **Size checks:** small video/audio files under your thresholds are considered samples
 
-RemoveSamples is built with enterprise-grade practices:
-- **Automated security scanning** with CodeQL
-- **Dependency vulnerability monitoring** with Dependabot
-- **Comprehensive test coverage** with automated CI/CD
-- **Professional code review** workflow
+## Windows debug console note
 
-## 🏆 Official Recognition
+If you previously saw a Unicode/console encoding error with **Debug** enabled on Windows, update to the latest version via Extension Manager. The script now uses UTF-8 console output on Windows so Debug works normally.
 
-**🎉 RemoveSamples is now officially available in the NZBGet Extension Manager!**
+## NZBGet versions / requirements
 
-*RemoveSamples has been accepted by the NZBGet team and is available for one-click installation through the official Extension Manager.*
+* **NZBGet:** v23+ recommended
+* **Python:** 3.8+ (required)
 
-## 📋 Requirements
+## Support
 
-- **NZBGet**: Version 14.0 or later (21.0+ recommended)
-- **Python**: 3.8+ installed on your system
-- **Permissions**: Execute permission on main.py
+* **Bug Reports**: [GitHub Issues](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/issues)
+* **Discussions**: [GitHub Discussions](https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/discussions)
 
-## 🔧 Development
+## License
 
-### Running Tests
-```bash
-python -m unittest tests.py -v
-```
-
-### Code Quality Checks
-```bash
-pip install prospector
-prospector main.py
-```
-
-### Contributing
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feature-name`
-3. Make your changes with tests
-4. Ensure all tests pass: `python -m unittest tests.py -v`
-5. Submit a pull request
-
-**📖 [Development documentation →](../../wiki/10_Contributing)**
-
-## 📄 License
-
-GNU General Public License v2.0 - see [LICENSE](LICENSE) file for details.
-
-## 📈 Changelog
-
-### v1.0.1 - Official Release
-- ✅ **Official NZBGet adoption** - Available in Extension Manager
-- ✅ Modern NZBGet extension format with manifest.json
-- ✅ GUI dropdown configuration interface  
-- ✅ Advanced pattern matching with word boundaries
-- ✅ Comprehensive sample detection (files + directories)
-- ✅ Configurable video/audio size thresholds
-- ✅ Full test coverage with automated CI/CD
-- ✅ Docker and Unraid compatibility
-- ✅ Enterprise-grade security practices
-- ✅ Complete documentation wiki
-
----
-
-**Ready to get started?** → **[Installation Guide](../../wiki/Installation-Guide)**  
-**Need help?** → **[FAQ](../../wiki/FAQ)** | **[Troubleshooting](../../wiki/Troubleshooting-Guide)**
+**GNU General Public License v2.0** - see [LICENSE](LICENSE) file for details.

--- a/main.py
+++ b/main.py
@@ -29,6 +29,21 @@ import shutil
 import sys
 from pathlib import Path
 
+# Force UTF-8 console on Windows to avoid UnicodeEncodeError in debug logs
+if os.name == "nt":
+    try:
+        # Python 3.7+
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        # Fallback for older Pythons / odd consoles
+        try:
+            import codecs
+            sys.stdout = codecs.getwriter("utf-8")(getattr(sys.stdout, "buffer", sys.stdout), "replace")
+            sys.stderr = codecs.getwriter("utf-8")(getattr(sys.stderr, "buffer", sys.stderr), "replace")
+        except Exception:
+            pass  # Continue without changes if everything fails
+
 # --- NZBGet exit codes -----------------------------------------------------
 POSTPROCESS_SUCCESS = 93
 POSTPROCESS_ERROR = 94

--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ AUDIO_EXTS = {
 }
 
 DL_DIR = os.environ.get('NZBPP_DIRECTORY')
-DL_STATUS = os.environ.get('NZBPP_STATUS', '')
+DL_STATUS = os.environ.get('NZBPP_STATUS', '') or os.environ.get('NZBPP_TOTALSTATUS', '')
 DL_NAME = os.environ.get('NZBPP_NZBNAME', '')
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -47,8 +47,7 @@
             "value": "No",
             "description": [
                 "Enable detailed logging for troubleshooting and configuration testing",
-                "Set to Yes only during setup or when investigating issues",
-                "Testing Guide: https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/wiki/04_Testing_Guide"
+                "Set to Yes only during setup or when investigating issues"
             ],
             "select": ["Yes", "No"]
         },

--- a/manifest.json
+++ b/manifest.json
@@ -1,99 +1,100 @@
 {
-    "main": "main.py",
-    "name": "RemoveSamples",
-    "homepage": "https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet",
-    "kind": "POST-PROCESSING",
-    "displayName": "Remove Samples",
-    "version": "1.0.2",
-    "author": "Anunnaki-Astronaut",
-    "license": "GNU",
-    "about": "Modern NZBGet extension for intelligent sample file detection and removal. Automatically cleans sample files/directories before Sonarr/Radarr/Lidarr/Prowlarr processing.",
-    "queueEvents": "",
-    "requirements": [
-        "This script requires Python 3.8+ to be installed on your system."
-    ],
-"description": [
-        "RemoveSamples intelligently detects and removes sample files and directories",
-        "using advanced pattern matching and configurable size thresholds.",
-        "",
-        "🎯 SETUP:",
-        "1. Settings → Categories → [Your Category] → ExtensionScripts → Add 'RemoveSamples'",
-        "2. Place RemoveSamples AFTER unpack but BEFORE media manager processing"
-    ],
-    "options": [
-        {
-            "name": "RemoveDirectories",
-            "displayName": "Remove Directories",
-            "value": "Yes",
-            "description": [
-                "Delete entire directories with sample patterns (samples/, SAMPLE/, etc.)",
-                "Recommended: Yes - removes complete sample folder structures"
-            ],
-            "select": ["Yes", "No"]
-        },
-        {
-            "name": "RemoveFiles",
-            "displayName": "Remove Files", 
-            "value": "Yes",
-            "description": [
-                "Delete individual files containing sample patterns in filename",
-                "Recommended: Yes - removes files like movie.sample.mkv"
-            ],
-            "select": ["Yes", "No"]
-        },
-{
-            "name": "Debug",
-            "displayName": "Debug",
-            "value": "No",
-            "description": [
-                "Enable detailed logging for troubleshooting and configuration testing",
-                "Set to Yes only during setup or when investigating issues"
-            ],
-            "select": ["Yes", "No"]
-        },
-{
-            "name": "VideoSizeThresholdMB",
-            "displayName": "Video Size Threshold (MB)",
-            "value": 150,
-"description": [
-                "Maximum size (MB) for video files to be considered samples",
-                "Common presets: 50 (480p samples), 100 (720p samples), 150 (1080p samples), 300 (4K samples)",
-                "Higher values = more aggressive detection (range: 1-1000)"
-            ],
-"select": [1, 1000]
-        },
-        {
-            "name": "VideoExts",
-            "displayName": "Video Extensions",
-            "value": ".mkv,.mp4,.avi,.mov,.wmv,.flv,.webm,.ts,.m4v,.vob,.mpg,.mpeg,.iso",
-            "description": [
-                "Comma-separated video file extensions for size-based detection",
-                "Default covers most common formats. Add rare formats if needed."
-            ],
-            "select": []
-        },
-{
-            "name": "AudioSizeThresholdMB",
-            "displayName": "Audio Size Threshold (MB)",
-            "value": 2,
-"description": [
-                "Maximum size (MB) for audio files to be considered samples",
-                "Common presets: 1 (short clips), 2 (30s @ 320kbps), 4 (1min @ 320kbps), 8 (2min samples)",
-                "Set to 0 to disable audio size detection (range: 0-100)"
-            ],
-"select": [0, 100]
-        },
-        {
-            "name": "AudioExts",
-            "displayName": "Audio Extensions",
-            "value": ".mp3,.flac,.aac,.ogg,.wma,.m4a,.opus,.wav,.alac,.ape",
-            "description": [
-                "Comma-separated audio file extensions for size-based detection",
-                "Covers lossless (FLAC, WAV) and compressed (MP3, AAC) formats"
-            ],
-            "select": []
-        }
-    ],
-    "commands": [],
-    "taskTime": ""
+  "main": "main.py",
+  "name": "RemoveSamples",
+  "homepage": "https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet",
+  "kind": "POST-PROCESSING",
+  "displayName": "Remove Samples",
+  "version": "1.0.3",
+  "nzbgetMinVersion": "23",
+  "author": "Anunnaki-Astronaut",
+  "license": "GPL-2.0-only",
+  "about": "Modern NZBGet extension for intelligent sample file detection and removal. Automatically cleans sample files/directories before Sonarr/Radarr/Lidarr/Prowlarr processing.",
+  "queueEvents": "",
+  "requirements": [
+    "This script requires Python 3.8+ to be installed on your system."
+  ],
+  "description": [
+    "RemoveSamples intelligently detects and removes sample files and directories",
+    "using advanced pattern matching and configurable size thresholds.",
+    "",
+    "🎯 SETUP:",
+    "1. Settings → Categories → [Your Category] → ExtensionScripts → Add 'RemoveSamples'",
+    "2. Place RemoveSamples AFTER unpack but BEFORE media manager processing"
+  ],
+  "options": [
+    {
+      "name": "RemoveDirectories",
+      "displayName": "Remove Directories",
+      "value": "Yes",
+      "description": [
+        "Delete entire directories with sample patterns (samples/, SAMPLE/, etc.)",
+        "Recommended: Yes - removes complete sample folder structures"
+      ],
+      "select": ["Yes", "No"]
+    },
+    {
+      "name": "RemoveFiles",
+      "displayName": "Remove Files",
+      "value": "Yes",
+      "description": [
+        "Delete individual files containing sample patterns in filename",
+        "Recommended: Yes - removes files like movie.sample.mkv"
+      ],
+      "select": ["Yes", "No"]
+    },
+    {
+      "name": "Debug",
+      "displayName": "Debug",
+      "value": "No",
+      "description": [
+        "Enable detailed logging for troubleshooting and configuration testing",
+        "Set to Yes only during setup or when investigating issues"
+      ],
+      "select": ["Yes", "No"]
+    },
+    {
+      "name": "VideoSizeThresholdMB",
+      "displayName": "Video Size Threshold (MB)",
+      "value": 150,
+      "description": [
+        "Maximum size (MB) for video files to be considered samples",
+        "Common presets: 50 (480p samples), 100 (720p samples), 150 (1080p samples), 300 (4K samples)",
+        "Higher values = more aggressive detection (range: 1-1000)"
+      ],
+      "select": [1, 1000]
+    },
+    {
+      "name": "VideoExts",
+      "displayName": "Video Extensions",
+      "value": ".mkv,.mp4,.avi,.mov,.wmv,.flv,.webm,.ts,.m4v,.vob,.mpg,.mpeg,.iso",
+      "description": [
+        "Comma-separated video file extensions for size-based detection",
+        "Default covers most common formats. Add rare formats if needed."
+      ],
+      "select": []
+    },
+    {
+      "name": "AudioSizeThresholdMB",
+      "displayName": "Audio Size Threshold (MB)",
+      "value": 2,
+      "description": [
+        "Maximum size (MB) for audio files to be considered samples",
+        "Common presets: 1 (short clips), 2 (30s @ 320kbps), 4 (1min @ 320kbps), 8 (2min samples)",
+        "Set to 0 to disable audio size detection (range: 0-100)"
+      ],
+      "select": [0, 100]
+    },
+    {
+      "name": "AudioExts",
+      "displayName": "Audio Extensions",
+      "value": ".mp3,.flac,.aac,.ogg,.wma,.m4a,.opus,.wav,.alac,.ape",
+      "description": [
+        "Comma-separated audio file extensions for size-based detection",
+        "Covers lossless (FLAC, WAV) and compressed (MP3, AAC) formats"
+      ],
+      "select": []
+    }
+  ],
+  "commands": [],
+  "taskTime": ""
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet",
     "kind": "POST-PROCESSING",
     "displayName": "Remove Samples",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "Anunnaki-Astronaut",
     "license": "GNU",
     "about": "Modern NZBGet extension for intelligent sample file detection and removal. Automatically cleans sample files/directories before Sonarr/Radarr/Lidarr/Prowlarr processing.",


### PR DESCRIPTION
This PR syncs nzbgetcom/Extension-RemoveSamples with the upstream repo for v1.0.2.

Highlights:
- Fix: Force UTF-8 console output on Windows when Debug is enabled (prevents UnicodeEncodeError).
- Docs: Simplified README; clarified Extensions order (after ExtendedUnpacker, before Clean).
- Debug guidance: Use only during setup or troubleshooting.
- Cleanup: Removed old Testing Guide link from manifest; version set to "1.0.2".

Upstream release: https://github.com/Anunnaki-Astronaut/RemoveSamples-NZBGet/releases/tag/v1.0.2