### PR TITLE
ci: restore workflows removed by v1.1.1 sync

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,30 @@
+name: Manifest Check
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  manifest-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Check manifest.json exists
+      run: |
+        if [ ! -f manifest.json ]; then
+          echo "manifest.json not found!"
+          exit 1
+        fi
+        echo "manifest.json found"
+
+    - name: Validate JSON syntax
+      run: |
+        python -c "import json; json.load(open('manifest.json'))"
+        echo "manifest.json is valid JSON"

--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -1,0 +1,37 @@
+name: Prospector Python Static Analysis
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+
+jobs:
+  prospector:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install prospector[with_pyroma]
+
+    - name: Run Prospector
+      run: prospector --zero-exit main.py
+
+    - name: Upload Prospector report
+      uses: actions/upload-artifact@v5
+      if: always()
+      with:
+        name: prospector-report
+        path: prospector-report.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: extension release
+
+on:
+  push:
+    tags:
+    - "v*"
+
+jobs:
+  manifest:
+    uses: nzbgetcom/nzbget-extensions/.github/workflows/manifest.yml@main
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [manifest]
+    uses: nzbgetcom/nzbget-extensions/.github/workflows/extension-release.yml@main
+    with:
+      release-file-list: main.py manifest.json
+      release-file-name: removesamples
+      release-dir: RemoveSamples

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Run tests
+      run: |
+        python -m unittest tests.py -v


### PR DESCRIPTION
## Summary

Restores the four GitHub Actions workflows unintentionally deleted when #4 synchronized the v1.1.1 extension files.

## Restored workflows

- `manifest.yml`
- `prospector.yml`
- `release.yml`
- `tests.yml`

The files match their pre-#4 behavior. The only content cleanup is removal of trailing spaces from whitespace-only blank lines.

## Verification

- Diff contains exactly the four restored workflow files
- All workflow YAML files parse successfully
- `git diff --check` passes
- Existing Python regression suite passes: 16/16
- No extension source or documentation files are changed

## Release follow-up

After this PR is merged, please create and push tag `v1.1.1` from the resulting `main`. The restored `release.yml` workflow is configured to build the extension release when a `v*` tag is pushed. The v1.1.1 implementation is already present on `main` from #4; the upstream tag and GitHub Release are the remaining publication steps.